### PR TITLE
Support for Swift projects in a subdirectory of repo

### DIFF
--- a/lib/cocoapods-patch/command/patch/apply.rb
+++ b/lib/cocoapods-patch/command/patch/apply.rb
@@ -34,7 +34,7 @@ def apply_patch(patch_file)
   repo_root = `git rev-parse --show-toplevel`.strip
   ios_project_path = Pathname.new(working_dir).relative_path_from(Pathname.new(repo_root))
 
-  directory_arg = File.join(ios_project_path, 'Pods')
+  directory_arg = (ios_project_path.to_s.eql? ".") ? "Pods" : File.join(ios_project_path, 'Pods')
 
   Dir.chdir(repo_root) {
     check_cmd = "git apply --check #{patch_file} --directory=#{directory_arg} -p2 2> /dev/null"

--- a/lib/cocoapods-patch/command/patch/apply.rb
+++ b/lib/cocoapods-patch/command/patch/apply.rb
@@ -30,15 +30,24 @@ end
 
 # also used from the post-install hook
 def apply_patch(patch_file)
-  check_cmd = "git apply --check #{patch_file} --directory=Pods -p2 2> /dev/null"
-  can_apply = system(check_cmd)
-  if can_apply
-    apply_cmd = check_cmd.gsub('--check ', '')
-    did_apply = system(apply_cmd)
-    if did_apply
-      Pod::UI.puts "Successfully applied #{patch_file}"
-    else
-      Pod::UI.warn "Failed to apply #{patch_file}"
+  working_dir = Dir.pwd
+  repo_root = `git rev-parse --show-toplevel`.strip
+  ios_project_path = Pathname.new(working_dir).relative_path_from(Pathname.new(repo_root))
+
+  directory_arg = File.join(ios_project_path, 'Pods')
+
+  Dir.chdir(repo_root) {
+    check_cmd = "git apply --check #{patch_file} --directory=#{directory_arg} -p2 2> /dev/null"
+
+    can_apply = system(check_cmd)
+    if can_apply
+      apply_cmd = check_cmd.gsub('--check ', '')
+      did_apply = system(apply_cmd)
+      if did_apply
+        Pod::UI.puts "Successfully applied #{patch_file}"
+      else
+        Pod::UI.warn "Failed to apply #{patch_file}"
+      end
     end
-  end
+  }
 end


### PR DESCRIPTION
Hello!

My team uses a monorepo in which our iOS project does not live in the root directory of the repository. `cocoapods-patch` uses `git apply` to apply patches, however, `git apply` expects to be run from the root directory of the repository, otherwise it may finish with exit code 0 without apply any patches. (See https://stackoverflow.com/questions/24821431/git-apply-patch-fails-silently-no-errors-but-nothing-happens)

This PR adds support for iOS projects which live in a repo subdirectory by changing the working directory to the repository root, and when invoking `git apply`, join the `--directory` argument with the relative path between the iOS project directory and the repository root.

I set up a test repo for this directory here: https://github.com/zenithlight/cocoapods-patch-test

In order to demonstrate the fix:

1. `git@github.com:zenithlight/cocoapods-patch-test.git`

2. `cd cocoapods-patch-test`

3. `bundle install`

4. `pod install`

5. Inspect the contents of `Pods/AWSCore/AWSCore/Utility/AWSCategory.m`. Observe that despite the existence of a patch in `ios/patches` folder, the patch was not applied. Contents of file:

```
478 - (BOOL)aws_isVirtualHostedStyleCompliant {
479     if (![self aws_isDNSBucketName]) {
480         return NO;
481     } else {
482         return ![self aws_contains:@"."];
483     }
484 }
```

6. in `ios/Gemfile`, replace `gem 'cocoapods-patch'` with `gem 'cocoapods-patch', :git => 'https://github.com/zenithlight/cocoapods-patch.git'`

7. `bundle install`

8. `pod install`

9. Check contents of `Pods/AWSCore/AWSCore/Utility/AWSCategory.m` again. Contents of file:

```
478 - (BOOL)aws_isVirtualHostedStyleCompliant {
479     return NO;
480 }
```

Thanks for taking a look!